### PR TITLE
Changed the persistence models to store full ID in the references

### DIFF
--- a/Database/Models/BacklogItem/BacklogItem.cs
+++ b/Database/Models/BacklogItem/BacklogItem.cs
@@ -40,17 +40,17 @@ namespace Raven.Yabt.Database.Models.BacklogItem
 		///		List of all users who modified the ticket.
 		///		The first record is creation of the ticket
 		/// </summary>
-		public IList<BacklogItemHistoryRecord> Modifications { get; } = new List<BacklogItemHistoryRecord>();
+		public IList<BacklogItemHistoryRecord> ModifiedBy { get; } = new List<BacklogItemHistoryRecord>();
 
 		[JsonIgnore]
-		public ChangedByUserReference Created		=> Modifications.OrderBy(m => m.Timestamp).FirstOrDefault() as ChangedByUserReference;
+		public ChangedByUserReference Created		=> ModifiedBy.OrderBy(m => m.Timestamp).FirstOrDefault() as ChangedByUserReference;
 		[JsonIgnore]
-		public ChangedByUserReference LastUpdated	=> Modifications.OrderBy(m => m.Timestamp).LastOrDefault() as ChangedByUserReference;
+		public ChangedByUserReference LastUpdated	=> ModifiedBy.OrderBy(m => m.Timestamp).LastOrDefault() as ChangedByUserReference;
 
 		/// <summary>
-		///		Related tickets: { Backlog Item ID, Relationship type }.
+		///		Related tickets
 		/// </summary>
-		public IDictionary<string, BacklogItemRelatedItem> RelatedItems { get; set; } = new Dictionary<string, BacklogItemRelatedItem>();
+		public IList<BacklogItemRelatedItem> RelatedItems { get; set; } = new List<BacklogItemRelatedItem>();
 
 		/// <summary>
 		///		Comments on the ticket
@@ -63,9 +63,9 @@ namespace Raven.Yabt.Database.Models.BacklogItem
 		/// </summary>
 		public IDictionary<string, object> CustomFields { get; set; } = new Dictionary<string, object>();
 
-		public BacklogItemReference GetReference() => new BacklogItemReference
+		public BacklogItemReference ToReference() => new BacklogItemReference
 		{
-			Id = Id?.Split('/').Last(),
+			Id = Id,
 			Name = Title,
 			Type = Type
 		};

--- a/Database/Models/User.cs
+++ b/Database/Models/User.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 using Raven.Yabt.Database.Common;
 using Raven.Yabt.Database.Common.References;
@@ -34,7 +32,7 @@ namespace Raven.Yabt.Database.Models
 
 		public UserReference ToReference() => new UserReference
 		{
-			Id = Id?.Split('/').Last(),
+			Id = Id,
 			Name = ShortName,
 			FullName = FullName,
 			Avatar = Avatar

--- a/Domain/BacklogItemServices/ByIdQuery/DTOs/ConvertionExtensions.cs
+++ b/Domain/BacklogItemServices/ByIdQuery/DTOs/ConvertionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Raven.Yabt.Database.Models.BacklogItem;
+﻿using Raven.Yabt.Database.Common.References;
+using Raven.Yabt.Database.Models.BacklogItem;
+using Raven.Yabt.Domain.Helpers;
 
 namespace Raven.Yabt.Domain.BacklogItemServices.ByIdQuery.DTOs
 {
@@ -21,6 +23,7 @@ namespace Raven.Yabt.Domain.BacklogItemServices.ByIdQuery.DTOs
 				CustomFields = entity.CustomFields,
 				Type = entity.Type
 			};
+			response.RemoveEntityPrefixFromIds(r => r.Created.ActionedBy, r => r.LastUpdated.ActionedBy);
 
 			if (entity is BacklogItemBug entityBug 
 				&& response is BugGetResponse responseBug)

--- a/Domain/BacklogItemServices/Commands/DTOs/BacklogItemAddUpdRequest.cs
+++ b/Domain/BacklogItemServices/Commands/DTOs/BacklogItemAddUpdRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-using Raven.Yabt.Database.Models.BacklogItem;
+using Raven.Yabt.Database.Common;
 
 namespace Raven.Yabt.Domain.BacklogItemServices.Commands.DTOs
 {
@@ -18,10 +18,10 @@ namespace Raven.Yabt.Domain.BacklogItemServices.Commands.DTOs
 		/// <summary>
 		///		Related tickets: { Backlog Item ID, Relationship type }.
 		/// </summary>
-		public IDictionary<string, BacklogItemRelatedItem>? RelatedItems { get; set; }
+		public IDictionary<string, BacklogRelationshipType>? RelatedItems { get; set; }
 
 		/// <summary>
-		///		Extra custom properties of various data types configured by the user,
+		///		Extra custom properties of various data types configured by the user: { Custom Field ID, Value }.
 		/// </summary>
 		public IDictionary<string, object>? CustomFields { get; set; }
 	}

--- a/Domain/Common/BaseService.cs
+++ b/Domain/Common/BaseService.cs
@@ -1,5 +1,6 @@
 ﻿using Raven.Client.Documents.Session;
 using Raven.Yabt.Database.Common;
+using Raven.Yabt.Domain.Helpers;
 
 namespace Raven.Yabt.Domain.Common
 {
@@ -12,6 +13,6 @@ namespace Raven.Yabt.Domain.Common
 			DbSession = dbSession;
 		}
 
-		protected string GetFullId(string id) => $"{typeof(TEntity).Name}s/{id}";
+		protected string GetFullId(string id) => id.GetFullId<TEntity>();
 	}
 }

--- a/Domain/CustomFieldServices/Command/CustomFieldCommandService.cs
+++ b/Domain/CustomFieldServices/Command/CustomFieldCommandService.cs
@@ -15,7 +15,7 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Command
 	{
 		public CustomFieldCommandService(IAsyncDocumentSession dbSession) : base(dbSession)	{}
 
-		public async Task<CustomFieldReference> Create(CustomFieldAddRequest dto)
+		public async Task<CustomFieldReferenceDto> Create(CustomFieldAddRequest dto)
 		{
 			if (await DbSession.Query<CustomFieldIndexedForList, CustomFields_ForList>()
 							   .Where(cf => cf.Name == dto.Name)
@@ -32,7 +32,7 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Command
 			return GetReference(entity);
 		}
 
-		public async Task<CustomFieldReference?> Delete(string id)
+		public async Task<CustomFieldReferenceDto?> Delete(string id)
 		{
 			// TODO: Prohibit deletion if there are any references
 
@@ -45,7 +45,7 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Command
 			return GetReference(cf);
 		}
 
-		public async Task<CustomFieldReference?> Rename(string id, CustomFieldRenameRequest dto)
+		public async Task<CustomFieldReferenceDto?> Rename(string id, CustomFieldRenameRequest dto)
 		{
 			if (dto?.Name == null)
 				throw new ArgumentNullException(nameof(dto));
@@ -59,6 +59,6 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Command
 			return GetReference(entity);
 		}
 
-		private CustomFieldReference GetReference (CustomField entity) => new CustomFieldReference { Id = entity.Id, Name = entity.Name };
+		private CustomFieldReferenceDto GetReference (CustomField entity) => new CustomFieldReferenceDto { Id = entity.Id, Name = entity.Name };
 	}
 }

--- a/Domain/CustomFieldServices/Command/DTOs/CustomFieldReferenceDto.cs
+++ b/Domain/CustomFieldServices/Command/DTOs/CustomFieldReferenceDto.cs
@@ -6,7 +6,7 @@ using Raven.Yabt.Database.Common.References;
 
 namespace Raven.Yabt.Domain.CustomFieldServices.Command.DTOs
 {
-	public class CustomFieldReference : IEntityReference
+	public class CustomFieldReferenceDto : IEntityReference
 	{
 		private string _id;
 

--- a/Domain/CustomFieldServices/Command/ICustomFieldCommandService.cs
+++ b/Domain/CustomFieldServices/Command/ICustomFieldCommandService.cs
@@ -6,10 +6,10 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Command
 {
 	public interface ICustomFieldCommandService
 	{
-		Task<CustomFieldReference> Create(CustomFieldAddRequest dto);
+		Task<CustomFieldReferenceDto> Create(CustomFieldAddRequest dto);
 
-		Task<CustomFieldReference?> Rename(string id, CustomFieldRenameRequest dto);
+		Task<CustomFieldReferenceDto?> Rename(string id, CustomFieldRenameRequest dto);
 
-		Task<CustomFieldReference?> Delete(string id);
+		Task<CustomFieldReferenceDto?> Delete(string id);
 	}
 }

--- a/Domain/CustomFieldServices/Query/CustomFieldQueryService.cs
+++ b/Domain/CustomFieldServices/Query/CustomFieldQueryService.cs
@@ -9,6 +9,7 @@ using Raven.Yabt.Database.Models.CustomField;
 using Raven.Yabt.Database.Models.CustomField.Indexes;
 using Raven.Yabt.Domain.Common;
 using Raven.Yabt.Domain.CustomFieldServices.Query.DTOs;
+using Raven.Yabt.Domain.Helpers;
 
 namespace Raven.Yabt.Domain.CustomFieldServices.Query
 {
@@ -29,6 +30,17 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Query
 			}
 
 			return query.ProjectInto<CustomFieldListGetResponse>().ToArrayAsync();
+		}
+
+		public async Task<IDictionary<string, string>> GetFullIdsOfExistingItems(IEnumerable<string> ids)
+		{
+			var fullIds = ids.Select(GetFullId);
+
+			var resolvedIds= await (from b in DbSession.Query<CustomFieldIndexedForList, CustomFields_ForList>()
+									where b.Id.In(fullIds)
+									select b.Id
+									).ToArrayAsync();
+			return resolvedIds.ToDictionary(id => id.ShortenId()!, id => id);
 		}
 	}
 }

--- a/Domain/CustomFieldServices/Query/ICustomFieldQueryService.cs
+++ b/Domain/CustomFieldServices/Query/ICustomFieldQueryService.cs
@@ -8,5 +8,7 @@ namespace Raven.Yabt.Domain.CustomFieldServices.Query
 	public interface ICustomFieldQueryService
 	{
 		Task<CustomFieldListGetResponse[]> GetArray(CustomFieldListGetRequest dto);
+
+		Task<IDictionary<string, string>> GetFullIdsOfExistingItems(IEnumerable<string> ids);
 	}
 }

--- a/Domain/Helpers/SanitiseReferenceIdsExtension.cs
+++ b/Domain/Helpers/SanitiseReferenceIdsExtension.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Raven.Client.Documents.Conventions;
+using Raven.Yabt.Database.Common;
+using Raven.Yabt.Database.Common.References;
+
+namespace Raven.Yabt.Domain.Helpers
+{
+	internal static class SanitiseReferenceIdsExtension
+	{
+		internal static void RemoveEntityPrefixFromIds<T, TReference>(this IEnumerable<T> targets, params Expression<Func<T, TReference>>[] referenceMemberLamdas) where TReference : IEntityReference
+		{
+			foreach (var target in targets)
+				target.RemoveEntityPrefixFromIds(referenceMemberLamdas);
+		}
+
+		internal static void RemoveEntityPrefixFromIds<T, TReference>(this T target, params Expression<Func<T, TReference>>[] referenceMemberLamdas) where TReference : IEntityReference
+		{
+			foreach (var referenceMember in referenceMemberLamdas)
+				target.RemoveEntityPrefixFromIds(referenceMember);
+		}
+
+		internal static void RemoveEntityPrefixFromIds<T, TReference>(this T target, Expression<Func<T, TReference>> referenceMemberLamda) where TReference : IEntityReference
+		{
+			if (!(referenceMemberLamda.Body is MemberExpression referenceMemberSelectorExpression))
+				return;
+
+			if (!(referenceMemberSelectorExpression.Member is PropertyInfo referenceProperty))
+				return;
+			
+			// Read the current reference
+			var referenceFunc = referenceMemberLamda.Compile();
+			var reference = referenceFunc(target);
+
+			if (reference == null)
+				return;
+
+			reference.RemoveEntityPrefixFromId();
+		}
+
+		internal static T RemoveEntityPrefixFromId<T>(this T target) where T: IEntityReference
+		{
+			// The new ID value without the entity prefix
+			var newRefId = target?.Id?.ShortenId();
+
+			if (newRefId == null)
+				return target;
+			var type = target!.GetType();
+			
+			var idProp = type.GetProperty(nameof(IEntityReference.Id));
+			if (idProp == null)
+				throw new NotImplementedException($"No public setter on '{nameof(IEntityReference.Id)}' property of '{type.Name}' type");
+
+			idProp.SetValue(target, newRefId, null);
+
+			return target;
+		}
+
+		internal static string? ShortenId(this string? fullId) => fullId?.Split('/').Last();
+
+		internal static string GetFullId<T>(this string id) where T: IEntity
+				=> $"{DocumentConventions.DefaultGetCollectionName(typeof(T))}/{id}";
+
+		internal static string GetIdForDynamicField<T>(this string id) where T : IEntity
+				=> id.GetFullId<T>().Replace("/", "").ToLower();
+	}
+}

--- a/Domain/UserServices/UserCommandService.cs
+++ b/Domain/UserServices/UserCommandService.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Session;
 using Raven.Yabt.Database.Common.References;
 using Raven.Yabt.Database.Models;
 using Raven.Yabt.Domain.Common;
+using Raven.Yabt.Domain.Helpers;
 using Raven.Yabt.Domain.UserServices.DTOs;
 
 namespace Raven.Yabt.Domain.UserServices
@@ -23,7 +24,7 @@ namespace Raven.Yabt.Domain.UserServices
 			var user = dto.ConvertToUser();
 			await DbSession.StoreAsync(user);
 
-			return user.ToReference();
+			return user.ToReference().RemoveEntityPrefixFromId();
 		}
 
 		public async Task<UserReference?> Delete(string id)
@@ -40,7 +41,7 @@ namespace Raven.Yabt.Domain.UserServices
 			foreach (var updateUserRef in _updateUserReferences)
 				updateUserRef.ClearUserId(id);
 
-			return user.ToReference();
+			return user.ToReference().RemoveEntityPrefixFromId();
 		}
 
 		public async Task<UserReference?> Update(string id, UserAddUpdRequest dto)
@@ -57,7 +58,7 @@ namespace Raven.Yabt.Domain.UserServices
 			foreach (var updateUserRef in _updateUserReferences)
 				updateUserRef.UpdateReferences(newRef);
 
-			return newRef;
+			return user.ToReference().RemoveEntityPrefixFromId();
 		}
 	}
 }

--- a/Tests/BacklogItemServices/BacklogItemCrudTests.cs
+++ b/Tests/BacklogItemServices/BacklogItemCrudTests.cs
@@ -34,7 +34,7 @@ namespace Raven.Yabt.Domain.Tests.BacklogItemServices
 			base.ConfigureIocContainer(services);
 
 			var userResolver = Substitute.For<IUserReferenceResolver>();
-			userResolver.GetCurrentUserReference().Returns(_currentUser);
+				userResolver.GetCurrentUserReference().Returns(_currentUser);
 			services.AddScoped(x => userResolver);
 		}
 

--- a/Tests/CustomFields/CustomFieldCrudTests.cs
+++ b/Tests/CustomFields/CustomFieldCrudTests.cs
@@ -77,7 +77,7 @@ namespace Raven.Yabt.Domain.Tests.CustomFields
 			Assert.False(record.Any());
 		}
 
-		private async Task<CustomFieldReference> CreateSampleCustomField()
+		private async Task<CustomFieldReferenceDto> CreateSampleCustomField()
 		{
 			var dto = new CustomFieldAddRequest
 			{


### PR DESCRIPTION
Main change - Changed the persistence models to store full ID (with the prefix) in the references.

Side changes:
 - Added checks that referred tickets and cutom field actually exist in the DB.
 - Reames ('BacklogItemRelatedItem' to 'BacklogRelationshipType', 'Modifications' to 'ModifiedBy', 'CustomFieldReference' to 'CustomFieldReferenceDto')