### PR TITLE
Modified way of injecting env variables to appsettings.json

### DIFF
--- a/back-end/WebApi/WebApi.csproj
+++ b/back-end/WebApi/WebApi.csproj
@@ -16,4 +16,18 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\Domain\Domain.csproj" />
 	</ItemGroup>
+	
+	<ItemGroup>
+		<Content Update="appsettings.docker.json">
+			<DependentUpon>appsettings.json</DependentUpon>
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</Content>
+		<Content Update="appsettings.json">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
 </Project>

--- a/back-end/WebApi/WebApi.csproj
+++ b/back-end/WebApi/WebApi.csproj
@@ -22,7 +22,7 @@
 			<DependentUpon>appsettings.json</DependentUpon>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
 		</Content>
 		<Content Update="appsettings.json">
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/back-end/WebApi/appsettings.docker.json
+++ b/back-end/WebApi/appsettings.docker.json
@@ -1,22 +1,6 @@
 {
 	"Database": {
 		"RavenDbUrls": [ "$SETTINGS_RAVENDB_URL" ],
-		"Certificate": "$SETTINGS_RAVENDB_CERTIFICATE",
-		"DbName": "Yabt",
-		"WaitForIndexesAfterSaveChanges": 30,
-		"LogWarningIfSavingTakesMoreThan": 15,
-		"LogErrorIfSavingTakesMoreThan": 30
-	},
-
-	"Logging": {
-		"LogLevel": {
-			"Default": "Information",
-			"Microsoft": "Warning",
-			"Microsoft.Hosting.Lifetime": "Information"
-		}
-	},
-	"ApplicationInsights": {
-		"InstrumentationKey": ""
-	},
-	"AllowedHosts": "*"
+		"Certificate": "$SETTINGS_RAVENDB_CERTIFICATE"
+	}
 }

--- a/back-end/WebApi/appsettings.docker.json
+++ b/back-end/WebApi/appsettings.docker.json
@@ -1,0 +1,22 @@
+{
+	"Database": {
+		"RavenDbUrls": [ "$SETTINGS_RAVENDB_URL" ],
+		"Certificate": "$SETTINGS_RAVENDB_CERTIFICATE",
+		"DbName": "Yabt",
+		"WaitForIndexesAfterSaveChanges": 30,
+		"LogWarningIfSavingTakesMoreThan": 15,
+		"LogErrorIfSavingTakesMoreThan": 30
+	},
+
+	"Logging": {
+		"LogLevel": {
+			"Default": "Information",
+			"Microsoft": "Warning",
+			"Microsoft.Hosting.Lifetime": "Information"
+		}
+	},
+	"ApplicationInsights": {
+		"InstrumentationKey": ""
+	},
+	"AllowedHosts": "*"
+}

--- a/back-end/WebApi/appsettings.json
+++ b/back-end/WebApi/appsettings.json
@@ -2,12 +2,15 @@
 	"Database": {
 		"RavenDbUrls": [ "https://xxx.ravendb.cloud" ],
 		"Certificate": "",
-		"DbName": "Yabt",
+		"DbName": "Yabt1",
 		"WaitForIndexesAfterSaveChanges": 30,
 		"LogWarningIfSavingTakesMoreThan": 15,
 		"LogErrorIfSavingTakesMoreThan": 30
 	},
-
+	"UserApiKey": [{
+		"UserId": "1864-A",
+		"ApiKey": "4D84AE02-C989-4DC5-9518-8D0CB2FB5F61"
+	}],
 	"Logging": {
 		"LogLevel": {
 			"Default": "Information",

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
 
 WORKDIR /build
 COPY . /build
-RUN dotnet restore \
+RUN dotnet restore back-end/WebApi/WebApi.csproj \
     && mkdir -p /publish \
     && dotnet publish -c Release -o /publish back-end/WebApi/WebApi.csproj \
     && cp devops/run.sh /publish/run.sh
@@ -11,6 +11,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 
 COPY --from=build /publish /app
 WORKDIR /app
-ENV APP_SETTINGS='{}' 
+ENV SETTINGS_RAVENDB_URL='' SETTINGS_RAVENDB_CERTIFICATE='' 
+RUN apt-get update && apt-get install -y gettext
 
 CMD bash ./run.sh

--- a/devops/run.sh
+++ b/devops/run.sh
@@ -10,6 +10,6 @@ if [ -z "$SETTINGS_RAVENDB_CERTIFICATE" ]; then
     exit 2
 fi
 
-envsubst < appsettings.docker.json > appsettings.json
+envsubst < appsettings.docker.json > appsettings.docker.json
 
-exec dotnet WebApi.dll
+exec dotnet WebApi.dll --environment=docker

--- a/devops/run.sh
+++ b/devops/run.sh
@@ -1,10 +1,15 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if [ -z "$APP_SETTINGS" ]; then
-    echo "APP_SETTINGS is required."
+if [ -z "$SETTINGS_RAVENDB_URL" ]; then
+    echo "SETTINGS_RAVENDB_URL env var is required."
     exit 1
-else
-    echo "$APP_SETTINGS" > appsettings.json
 fi
 
-dotnet WebApi.dll
+if [ -z "$SETTINGS_RAVENDB_CERTIFICATE" ]; then
+    echo "SETTINGS_RAVENDB_CERTIFICATE env var is required."
+    exit 2
+fi
+
+envsubst < appsettings.docker.json > appsettings.json
+
+exec dotnet WebApi.dll

--- a/devops/run.sh
+++ b/devops/run.sh
@@ -10,13 +10,4 @@ if [ -z "$SETTINGS_RAVENDB_CERTIFICATE" ]; then
     exit 2
 fi
 
-cat <<SETTINGS > appsettings.docker.json
-{
-	"Database": {
-		"RavenDbUrls": [ "$SETTINGS_RAVENDB_URL" ],
-		"Certificate": "$SETTINGS_RAVENDB_CERTIFICATE"
-	}
-}
-SETTINGS
-
 exec dotnet WebApi.dll --environment=docker

--- a/devops/scripts/build-webapi-image.ps1
+++ b/devops/scripts/build-webapi-image.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-docker build -t yabt -f $PSScriptRoot\..\Dockerfile "$PSScriptRoot\.."
+docker build -t yabt -f $PSScriptRoot\..\Dockerfile "$PSScriptRoot\..\.."
 
 if ($LASTEXITCODE -ne 0) {
     throw "Failed to build Docker image."

--- a/devops/scripts/cert-to-base64.ps1
+++ b/devops/scripts/cert-to-base64.ps1
@@ -1,4 +1,4 @@
 param([string]$CertPath)
-
-$base64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($CertPath))
+$fullPath = Resolve-Path $CertPath
+$base64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($fullPath))
 Write-Output "$base64"


### PR DESCRIPTION
Based on Greg's PR #12.
I reduced the size of `appsettings.docker.json` so it contains only parameters that get overwritten. It led to settings the running environment in container to `docker`, so settings from the `appsettings.docker.json` get automatically merged with `appsettings.json`